### PR TITLE
add: norwegian kroner

### DIFF
--- a/backend/internal/core/currencies/currencies.json
+++ b/backend/internal/core/currencies/currencies.json
@@ -625,9 +625,9 @@
   },
   {
     "code": "NOK",
-    "local": "Norge",
+    "local": "Norway",
     "symbol": "kr",
-    "name": "Norske kroner"
+    "name": "Norwegian Krone"
   },
   {
     "code": "UAH",

--- a/backend/internal/core/currencies/currencies.json
+++ b/backend/internal/core/currencies/currencies.json
@@ -624,6 +624,12 @@
     "name": "Nicaraguan Córdoba"
   },
   {
+    "code": "NOK",
+    "local": "Norge",
+    "symbol": "kr",
+    "name": "Norske kroner"
+  },
+  {
     "code": "UAH",
     "local": "Ukraine",
     "symbol": "₴",


### PR DESCRIPTION
Adding the currency of norwegian krones back into the file. There was an earlier commit where this seems to have dropped of the table.

## What type of PR is this?

- feature

## What this PR does / why we need it:

The currency is currently missing. Danish and swedish money is in though.

## Which issue(s) this PR fixes:

- lacking currency

## Testing

I've built a Dockerimage, fired up the application and were able to change the currency to "Norwegien Krone."

## Release Notes

```release-note
Adding support for the norwegian currency NOK.
```